### PR TITLE
MVP: Lab Assistant — voice-first note capture, search, and summaries

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals", "next/typescript"]
+}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,178 @@
-# hello-world
-Repositorio de prueba
-Primer test 
+# Lab Assistant (MVP)
+
+A **voice-first scientific notebook** for researchers who need to capture observations with minimal interruption during lab work.
+
+The app is designed to feel like a practical lab assistant: tap once, dictate, auto-transcribe, store with timestamps and experiment context, then retrieve quickly with search and filters.
+
+---
+
+## Product description (concise)
+
+**Lab Assistant** is a lightweight web app for real-time experiment note capture. It prioritizes reliable recording and retrieval over heavy workflows. Scientists can:
+
+- capture voice notes in one tap,
+- review/edit transcription to correct scientific terms,
+- tag notes with project, experiment session, subject, and sample IDs,
+- search via date, subject, project, experiment, tags, or full text,
+- see timelines and per-experiment summaries.
+
+---
+
+## MVP pages
+
+- **Dashboard** (`/`): today’s notes, quick actions, recent experiments, timeline.
+- **Record** (`/record`): large voice-capture widget.
+- **Notes list** (`/notes`): collapsible filters + full-text search.
+- **Experiment/session detail** (`/experiments/[id]`): notes, attachments placeholder, auto summary.
+- **Subject/tag view** (`/subjects/[slug]`): grouped notes by theme.
+- **Settings** (`/settings`): provider/config placeholders + NL query examples.
+
+---
+
+## Suggested folder structure
+
+```text
+app/
+  api/
+    notes/
+    search/
+    summaries/
+  experiments/[id]/
+  notes/
+  record/
+  settings/
+  subjects/[slug]/
+  globals.css
+  layout.tsx
+  page.tsx
+components/
+  NoteCard.tsx
+  NotesFilters.tsx
+  RecordWidget.tsx
+  Timeline.tsx
+lib/
+  ai.ts
+  ai-prompts.md
+  sample-data.ts
+  store.ts
+  types.ts
+db/
+  schema.sql
+  seed.sql
+```
+
+---
+
+## Database schema
+
+A relational schema is included in `db/schema.sql` with the requested entities:
+
+- `users`
+- `projects`
+- `subjects`
+- `experiment_sessions`
+- `notes`
+- `tags`
+- `note_tags`
+- `task_reminders`
+- `attachments`
+
+The `notes` table includes all requested note fields (`created_at`, audio URL, raw/edited transcript, ai summary, category, tags via join table, project/session links, sample ID, note type, linked tasks via task table).
+
+---
+
+## Main React components
+
+- `RecordWidget`: big, glove-friendly recording CTA with status feedback.
+- `NoteCard`: displays raw transcript vs edited note clearly.
+- `NotesFilters`: date/subject/project/experiment/full-text filtering.
+- `Timeline`: chronological display of notes.
+
+---
+
+## API routes (MVP)
+
+- `GET /api/notes` – list all notes.
+- `POST /api/notes` – create note, with mock AI metadata suggestions.
+- `PATCH /api/notes/:id` – edit transcription/title/tags.
+- `POST /api/search` – natural-language-like keyword retrieval.
+- `GET /api/summaries/daily?date=YYYY-MM-DD` – daily summary.
+- `GET /api/summaries/experiment/:id` – experiment summary.
+
+> Note: MVP uses in-memory storage (`lib/store.ts`) for simplicity. Replace with Supabase/PostgreSQL in production.
+
+---
+
+## Seed/sample data
+
+Included in `lib/sample-data.ts`:
+
+- Projects: Hydrogel mechanics, Cell viability.
+- Subjects: cell culture, microscopy, scaffold fabrication, FEM, reagents, troubleshooting.
+- Sessions: hydrogel stiffness run + chondrocyte culture week 2.
+- Example voice-note entries include:
+  - possible B7 UV over-cure issue,
+  - compression test result (32 kPa),
+  - incubator humidity troubleshooting,
+  - C2 vs B7 viability observation and follow-up task.
+
+---
+
+## Setup & run instructions
+
+### 1) Install dependencies
+
+```bash
+npm install
+```
+
+### 2) Run locally
+
+```bash
+npm run dev
+```
+
+Open: `http://localhost:3000`
+
+### 3) Build for production
+
+```bash
+npm run build
+npm run start
+```
+
+---
+
+## Notes on voice transcription
+
+For MVP speed, the record button is mocked for transcription completion. Production options:
+
+- Web Speech API (browser native),
+- OpenAI Whisper API,
+- Deepgram / AssemblyAI.
+
+Integrate by replacing `startMockRecording` in `RecordWidget.tsx` and posting transcript + metadata to `/api/notes`.
+
+---
+
+## AI-assisted behavior currently covered
+
+- Metadata suggestion after transcription (`lib/ai.ts`):
+  - short title,
+  - tags,
+  - likely subject,
+  - note type (observation/result/reminder/issue/next_step).
+- Daily summary generation.
+- Per-experiment summary generation (objective/observations/anomalies/next actions).
+- Basic action-item detection via note type and linked task seed data.
+
+Sample prompt templates for plugging in an LLM provider are in `lib/ai-prompts.md`.
+
+---
+
+## Why this MVP is intentionally simple
+
+- Minimal-click capture is prioritized.
+- Data model already supports advanced AI and attachments.
+- Storage is in-memory for fast demo/testing; can be swapped to Postgres/Supabase.
+- UI is clean/responsive for desktop + tablet and can be used with limited attention.

--- a/app/api/notes/[id]/route.ts
+++ b/app/api/notes/[id]/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getNoteById } from "@/lib/store";
+
+export async function PATCH(request: NextRequest, { params }: { params: { id: string } }) {
+  const note = getNoteById(params.id);
+  if (!note) {
+    return NextResponse.json({ error: "Note not found" }, { status: 404 });
+  }
+
+  const body = await request.json();
+  note.transcriptEdited = body.transcriptEdited ?? note.transcriptEdited;
+  note.tags = body.tags ?? note.tags;
+  note.title = body.title ?? note.title;
+
+  return NextResponse.json(note);
+}

--- a/app/api/notes/route.ts
+++ b/app/api/notes/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from "next/server";
+import { suggestMetadata } from "@/lib/ai";
+import { db } from "@/lib/store";
+
+export async function GET() {
+  return NextResponse.json(db.notes);
+}
+
+export async function POST(request: NextRequest) {
+  const body = await request.json();
+  const transcriptRaw = String(body.transcriptRaw || "");
+  const suggestions = suggestMetadata(transcriptRaw);
+
+  const newNote = {
+    id: `n${db.notes.length + 1}`,
+    createdAt: new Date().toISOString(),
+    date: new Date().toISOString().slice(0, 10),
+    audioFileUrl: body.audioFileUrl || "/audio/new.wav",
+    transcriptRaw,
+    transcriptEdited: body.transcriptEdited || transcriptRaw,
+    aiSummary: body.aiSummary || suggestions.title,
+    title: body.title || suggestions.title,
+    category: body.category || suggestions.likelySubject,
+    tags: body.tags || suggestions.tags,
+    projectId: body.projectId || "p1",
+    experimentSessionId: body.experimentSessionId || "e1",
+    subjectId: body.subjectId || "s1",
+    sampleId: body.sampleId,
+    noteType: body.noteType || suggestions.noteType,
+    linkedTasks: []
+  };
+
+  db.notes.unshift(newNote);
+  return NextResponse.json(newNote, { status: 201 });
+}

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/lib/store";
+
+export async function POST(request: NextRequest) {
+  const { query } = await request.json();
+  const normalized = String(query || "").toLowerCase();
+
+  const matches = db.notes.filter((note) => {
+    const blob = `${note.date} ${note.title} ${note.transcriptEdited} ${note.sampleId || ""} ${note.tags.join(" ")}`.toLowerCase();
+    return blob.includes(normalized);
+  });
+
+  return NextResponse.json({
+    query,
+    count: matches.length,
+    matches
+  });
+}

--- a/app/api/summaries/daily/route.ts
+++ b/app/api/summaries/daily/route.ts
@@ -1,0 +1,9 @@
+import { NextRequest, NextResponse } from "next/server";
+import { summarizeDaily } from "@/lib/ai";
+import { db } from "@/lib/store";
+
+export async function GET(request: NextRequest) {
+  const date = request.nextUrl.searchParams.get("date") || new Date().toISOString().slice(0, 10);
+  const notes = db.notes.filter((note) => note.date === date);
+  return NextResponse.json({ date, summary: summarizeDaily(notes), notesCount: notes.length });
+}

--- a/app/api/summaries/experiment/[id]/route.ts
+++ b/app/api/summaries/experiment/[id]/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from "next/server";
+import { summarizeExperiment } from "@/lib/ai";
+import { db } from "@/lib/store";
+
+export async function GET(_: Request, { params }: { params: { id: string } }) {
+  const notes = db.notes.filter((note) => note.experimentSessionId === params.id);
+  if (notes.length === 0) {
+    return NextResponse.json({ error: "Experiment not found or no notes" }, { status: 404 });
+  }
+
+  return NextResponse.json(summarizeExperiment(notes));
+}

--- a/app/experiments/[id]/page.tsx
+++ b/app/experiments/[id]/page.tsx
@@ -1,0 +1,41 @@
+import { notFound } from "next/navigation";
+import NoteCard from "@/components/NoteCard";
+import { summarizeExperiment } from "@/lib/ai";
+import { experimentSessions, projects } from "@/lib/sample-data";
+import { db } from "@/lib/store";
+
+export default function ExperimentDetailPage({ params }: { params: { id: string } }) {
+  const session = experimentSessions.find((e) => e.id === params.id);
+  if (!session) return notFound();
+
+  const notes = db.notes.filter((n) => n.experimentSessionId === session.id);
+  const project = projects.find((p) => p.id === session.projectId);
+  const summary = summarizeExperiment(notes);
+
+  return (
+    <div className="grid">
+      <section className="card">
+        <h2>{session.name}</h2>
+        <p><strong>Project:</strong> {project?.name}</p>
+        <p><strong>Objective:</strong> {session.objective}</p>
+        <h3>Auto summary</h3>
+        <p><strong>Objective:</strong> {summary.objective}</p>
+        <p><strong>Observations:</strong> {summary.observations.join(" | ") || "None"}</p>
+        <p><strong>Anomalies:</strong> {summary.anomalies.join(" | ") || "None"}</p>
+        <pre>{summary.nextActions || "No actions detected"}</pre>
+      </section>
+
+      <section className="card">
+        <h3>Attachments (MVP placeholder)</h3>
+        <p className="muted">No files uploaded yet. Add microscopy images / CSV files in next iteration.</p>
+      </section>
+
+      <section className="grid">
+        <h3>Session notes ({notes.length})</h3>
+        {notes.map((note) => (
+          <NoteCard key={note.id} note={note} />
+        ))}
+      </section>
+    </div>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,68 @@
+:root {
+  color-scheme: light dark;
+  --bg: #f8fafc;
+  --fg: #0f172a;
+  --muted: #475569;
+  --card: #ffffff;
+  --accent: #2563eb;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #020617;
+    --fg: #e2e8f0;
+    --muted: #94a3b8;
+    --card: #0f172a;
+    --accent: #60a5fa;
+  }
+}
+
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: Inter, system-ui, -apple-system, sans-serif;
+  background: var(--bg);
+  color: var(--fg);
+}
+.topbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: end;
+  gap: 1rem;
+  padding: 1rem 1.5rem;
+  border-bottom: 1px solid #cbd5e1;
+}
+nav { display: flex; gap: 1rem; flex-wrap: wrap; }
+a { color: var(--accent); text-decoration: none; font-weight: 600; }
+.container { padding: 1rem 1.5rem 2rem; max-width: 1100px; margin: 0 auto; }
+.card {
+  background: var(--card);
+  border: 1px solid #cbd5e1;
+  border-radius: 12px;
+  padding: 1rem;
+}
+.grid { display: grid; gap: 1rem; }
+.grid.two { grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); }
+.muted { color: var(--muted); }
+.big-btn {
+  width: 100%;
+  min-height: 74px;
+  font-size: 1.2rem;
+  border: none;
+  border-radius: 14px;
+  background: var(--accent);
+  color: white;
+  font-weight: 700;
+}
+.note-card h4 { margin: 0; }
+.kbd { font-family: ui-monospace, monospace; background: #cbd5e1; color: #0f172a; padding: 0.1rem 0.4rem; border-radius: 4px; }
+.filters { display: grid; grid-template-columns: repeat(auto-fit, minmax(170px, 1fr)); gap: 0.5rem; margin-bottom: 1rem; }
+input, select, textarea {
+  width: 100%;
+  padding: 0.55rem;
+  border-radius: 8px;
+  border: 1px solid #94a3b8;
+  background: transparent;
+  color: inherit;
+}
+.timeline-item { border-left: 3px solid var(--accent); padding-left: 0.9rem; margin: 0.75rem 0; }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,30 @@
+import "./globals.css";
+import Link from "next/link";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Lab Assistant",
+  description: "Voice-first scientific notebook for real-time lab observations."
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <header className="topbar">
+          <div>
+            <h1>Lab Assistant</h1>
+            <p className="muted">Capture, transcribe, and retrieve lab notes in real time.</p>
+          </div>
+          <nav>
+            <Link href="/">Dashboard</Link>
+            <Link href="/record">Record</Link>
+            <Link href="/notes">Notes</Link>
+            <Link href="/settings">Settings</Link>
+          </nav>
+        </header>
+        <main className="container">{children}</main>
+      </body>
+    </html>
+  );
+}

--- a/app/notes/page.tsx
+++ b/app/notes/page.tsx
@@ -1,0 +1,14 @@
+import NotesFilters from "@/components/NotesFilters";
+import { db } from "@/lib/store";
+
+export default function NotesPage() {
+  return (
+    <div className="grid">
+      <section className="card">
+        <h2>Notes list</h2>
+        <p className="muted">Retrieve by date, subject, project, experiment, tags, and full-text query.</p>
+      </section>
+      <NotesFilters notes={db.notes} />
+    </div>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,59 @@
+import Link from "next/link";
+import RecordWidget from "@/components/RecordWidget";
+import Timeline from "@/components/Timeline";
+import { db } from "@/lib/store";
+import { experimentSessions, projects, subjects } from "@/lib/sample-data";
+import { summarizeDaily } from "@/lib/ai";
+
+export default function DashboardPage() {
+  const today = "2026-04-15";
+  const todaysNotes = db.notes.filter((n) => n.date === today);
+  const dailySummary = summarizeDaily(todaysNotes);
+
+  return (
+    <div className="grid" style={{ gap: "1rem" }}>
+      <section className="card">
+        <h2>Today at a glance</h2>
+        <p className="muted">{today}</p>
+        <p>{dailySummary}</p>
+        <div className="grid two">
+          <div className="card">
+            <h3>{todaysNotes.length}</h3>
+            <p className="muted">Notes captured today</p>
+          </div>
+          <div className="card">
+            <h3>{experimentSessions.length}</h3>
+            <p className="muted">Recent experiment sessions</p>
+          </div>
+        </div>
+      </section>
+
+      <RecordWidget />
+
+      <section className="card">
+        <h2>Quick actions</h2>
+        <div className="grid two">
+          <Link className="card" href="/notes">Open notes + filters</Link>
+          <Link className="card" href="/experiments/e1">Current experiment page</Link>
+          <Link className="card" href="/subjects/cell-culture">Subject view: cell culture</Link>
+          <Link className="card" href="/settings">Settings / integrations</Link>
+        </div>
+      </section>
+
+      <Timeline notes={todaysNotes} />
+
+      <section className="card">
+        <h2>Recent experiments</h2>
+        {experimentSessions.map((session) => {
+          const project = projects.find((p) => p.id === session.projectId)?.name;
+          const subject = subjects.find((s) => s.id === session.subjectId)?.name;
+          return (
+            <p key={session.id}>
+              <Link href={`/experiments/${session.id}`}>{session.name}</Link> · {project} · {subject}
+            </p>
+          );
+        })}
+      </section>
+    </div>
+  );
+}

--- a/app/record/page.tsx
+++ b/app/record/page.tsx
@@ -1,0 +1,17 @@
+import RecordWidget from "@/components/RecordWidget";
+
+export default function RecordPage() {
+  return (
+    <div className="grid">
+      <RecordWidget />
+      <section className="card">
+        <h3>Recording tips for gloved/low-attention use</h3>
+        <ul>
+          <li>Use the large button (single tap) and immediate audio cue.</li>
+          <li>Speak sample IDs and units clearly (e.g., “B7”, “32 kPa”).</li>
+          <li>Edit transcription immediately after capture to reduce scientific errors.</li>
+        </ul>
+      </section>
+    </div>
+  );
+}

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,0 +1,36 @@
+export default function SettingsPage() {
+  return (
+    <div className="grid">
+      <section className="card">
+        <h2>Settings</h2>
+        <p>Email login, speech-to-text provider, and AI summarization keys can be configured here in production.</p>
+        <div className="grid two">
+          <label>
+            Speech-to-text provider
+            <select defaultValue="webspeech">
+              <option value="webspeech">Web Speech API (default)</option>
+              <option value="deepgram">Deepgram</option>
+              <option value="whisper">Whisper API</option>
+            </select>
+          </label>
+          <label>
+            Auto-generate daily summary
+            <select defaultValue="enabled">
+              <option value="enabled">Enabled</option>
+              <option value="disabled">Disabled</option>
+            </select>
+          </label>
+        </div>
+      </section>
+
+      <section className="card">
+        <h3>Natural language examples</h3>
+        <ul>
+          <li><span className="kbd">show me everything from March 12 about chondrocyte culture</span></li>
+          <li><span className="kbd">what did I say last week about sample B7</span></li>
+          <li><span className="kbd">summarize my notes on hydrogel stiffness</span></li>
+        </ul>
+      </section>
+    </div>
+  );
+}

--- a/app/subjects/[slug]/page.tsx
+++ b/app/subjects/[slug]/page.tsx
@@ -1,0 +1,20 @@
+import NoteCard from "@/components/NoteCard";
+import { db } from "@/lib/store";
+import { subjects } from "@/lib/sample-data";
+
+export default function SubjectPage({ params }: { params: { slug: string } }) {
+  const subject = subjects.find((s) => s.slug === params.slug);
+  const notes = subject ? db.notes.filter((n) => n.subjectId === subject.id) : [];
+
+  return (
+    <div className="grid">
+      <section className="card">
+        <h2>Subject view: {subject?.name ?? params.slug}</h2>
+        <p className="muted">Grouped notes for a specific theme.</p>
+      </section>
+      {notes.map((note) => (
+        <NoteCard key={note.id} note={note} />
+      ))}
+    </div>
+  );
+}

--- a/components/NoteCard.tsx
+++ b/components/NoteCard.tsx
@@ -1,0 +1,16 @@
+import { Note } from "@/lib/types";
+
+export default function NoteCard({ note }: { note: Note }) {
+  return (
+    <article className="card note-card">
+      <h4>{note.title}</h4>
+      <p className="muted">
+        {new Date(note.createdAt).toLocaleString()} · {note.category} · {note.noteType}
+      </p>
+      <p><strong>Raw transcript:</strong> {note.transcriptRaw}</p>
+      <p><strong>Edited note:</strong> {note.transcriptEdited}</p>
+      <p><strong>Tags:</strong> {note.tags.join(", ") || "none"}</p>
+      <p><strong>Sample:</strong> {note.sampleId ?? "n/a"}</p>
+    </article>
+  );
+}

--- a/components/NotesFilters.tsx
+++ b/components/NotesFilters.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Note } from "@/lib/types";
+import NoteCard from "@/components/NoteCard";
+
+export default function NotesFilters({ notes }: { notes: Note[] }) {
+  const [query, setQuery] = useState("");
+  const [date, setDate] = useState("");
+  const [subject, setSubject] = useState("");
+  const [project, setProject] = useState("");
+  const [experiment, setExperiment] = useState("");
+
+  const filtered = useMemo(() => {
+    return notes.filter((n) => {
+      const blob = `${n.title} ${n.transcriptEdited} ${n.tags.join(" ")}`.toLowerCase();
+      const matchesQuery = query ? blob.includes(query.toLowerCase()) : true;
+      const matchesDate = date ? n.date === date : true;
+      const matchesSubject = subject ? n.subjectId === subject : true;
+      const matchesProject = project ? n.projectId === project : true;
+      const matchesExperiment = experiment ? n.experimentSessionId === experiment : true;
+      return matchesQuery && matchesDate && matchesSubject && matchesProject && matchesExperiment;
+    });
+  }, [date, experiment, notes, project, query, subject]);
+
+  return (
+    <section>
+      <details open className="card">
+        <summary><strong>Search & filters</strong></summary>
+        <div className="filters">
+          <input placeholder="Keyword / full text" value={query} onChange={(e) => setQuery(e.target.value)} />
+          <input type="date" value={date} onChange={(e) => setDate(e.target.value)} />
+          <input placeholder="Subject id (e.g., s1)" value={subject} onChange={(e) => setSubject(e.target.value)} />
+          <input placeholder="Project id (e.g., p1)" value={project} onChange={(e) => setProject(e.target.value)} />
+          <input
+            placeholder="Experiment id (e.g., e1)"
+            value={experiment}
+            onChange={(e) => setExperiment(e.target.value)}
+          />
+        </div>
+      </details>
+      <div className="grid" style={{ marginTop: "1rem" }}>
+        {filtered.map((note) => (
+          <NoteCard key={note.id} note={note} />
+        ))}
+        {filtered.length === 0 ? <p className="muted">No notes match current filters.</p> : null}
+      </div>
+    </section>
+  );
+}

--- a/components/RecordWidget.tsx
+++ b/components/RecordWidget.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useState } from "react";
+
+export default function RecordWidget() {
+  const [status, setStatus] = useState("Idle");
+
+  const startMockRecording = () => {
+    setStatus("Recording...");
+    setTimeout(() => setStatus("Transcribed and saved (mock)."), 1800);
+  };
+
+  return (
+    <section className="card">
+      <h2>Voice-first capture</h2>
+      <p className="muted">Tap once and dictate. Optimized for minimal interruption during experiments.</p>
+      <button className="big-btn" onClick={startMockRecording}>
+        🎙️ Record Voice Note
+      </button>
+      <p>
+        Status: <strong>{status}</strong>
+      </p>
+      <p className="muted">MVP note: Web Speech API / external STT provider can plug into this button.</p>
+    </section>
+  );
+}

--- a/components/Timeline.tsx
+++ b/components/Timeline.tsx
@@ -1,0 +1,18 @@
+import { Note } from "@/lib/types";
+
+export default function Timeline({ notes }: { notes: Note[] }) {
+  const ordered = [...notes].sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+
+  return (
+    <section className="card">
+      <h3>Timeline</h3>
+      {ordered.map((note) => (
+        <div key={note.id} className="timeline-item">
+          <strong>{new Date(note.createdAt).toLocaleTimeString()}</strong>
+          <p>{note.title}</p>
+          <p className="muted">{note.experimentSessionId} · {note.tags.join(", ")}</p>
+        </div>
+      ))}
+    </section>
+  );
+}

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,0 +1,82 @@
+-- Core entities
+CREATE TABLE users (
+  id UUID PRIMARY KEY,
+  email TEXT UNIQUE NOT NULL,
+  name TEXT NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE projects (
+  id UUID PRIMARY KEY,
+  user_id UUID REFERENCES users(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  description TEXT,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE subjects (
+  id UUID PRIMARY KEY,
+  name TEXT NOT NULL,
+  slug TEXT UNIQUE NOT NULL
+);
+
+CREATE TABLE experiment_sessions (
+  id UUID PRIMARY KEY,
+  project_id UUID REFERENCES projects(id) ON DELETE CASCADE,
+  subject_id UUID REFERENCES subjects(id),
+  name TEXT NOT NULL,
+  objective TEXT,
+  started_at TIMESTAMPTZ NOT NULL,
+  ended_at TIMESTAMPTZ
+);
+
+CREATE TABLE tags (
+  id UUID PRIMARY KEY,
+  name TEXT UNIQUE NOT NULL
+);
+
+CREATE TABLE notes (
+  id UUID PRIMARY KEY,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  note_date DATE NOT NULL,
+  audio_file_url TEXT,
+  transcript_raw TEXT NOT NULL,
+  transcript_edited TEXT NOT NULL,
+  ai_summary TEXT,
+  title TEXT,
+  category TEXT,
+  sample_id TEXT,
+  note_type TEXT CHECK (note_type IN ('observation', 'result', 'reminder', 'issue', 'next_step')),
+  project_id UUID REFERENCES projects(id),
+  experiment_session_id UUID REFERENCES experiment_sessions(id),
+  subject_id UUID REFERENCES subjects(id)
+);
+
+CREATE TABLE note_tags (
+  note_id UUID REFERENCES notes(id) ON DELETE CASCADE,
+  tag_id UUID REFERENCES tags(id) ON DELETE CASCADE,
+  PRIMARY KEY (note_id, tag_id)
+);
+
+CREATE TABLE task_reminders (
+  id UUID PRIMARY KEY,
+  note_id UUID REFERENCES notes(id) ON DELETE CASCADE,
+  text TEXT NOT NULL,
+  done BOOLEAN DEFAULT FALSE,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE attachments (
+  id UUID PRIMARY KEY,
+  note_id UUID REFERENCES notes(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  url TEXT NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- retrieval performance
+CREATE INDEX idx_notes_date ON notes(note_date);
+CREATE INDEX idx_notes_project ON notes(project_id);
+CREATE INDEX idx_notes_experiment ON notes(experiment_session_id);
+CREATE INDEX idx_notes_subject ON notes(subject_id);
+CREATE INDEX idx_notes_fulltext ON notes USING GIN (to_tsvector('english', transcript_edited || ' ' || COALESCE(title, '')));

--- a/db/seed.sql
+++ b/db/seed.sql
@@ -1,0 +1,10 @@
+-- Seed file for quick local testing (UUIDs shortened here for readability)
+INSERT INTO subjects (id, name, slug) VALUES
+('00000000-0000-0000-0000-0000000000s1', 'Cell culture', 'cell-culture'),
+('00000000-0000-0000-0000-0000000000s2', 'Microscopy', 'microscopy'),
+('00000000-0000-0000-0000-0000000000s3', 'Scaffold fabrication', 'scaffold-fabrication'),
+('00000000-0000-0000-0000-0000000000s4', 'Finite element modeling', 'finite-element-modeling'),
+('00000000-0000-0000-0000-0000000000s5', 'Reagents', 'reagents'),
+('00000000-0000-0000-0000-0000000000s6', 'Troubleshooting', 'troubleshooting');
+
+-- Additional inserts omitted in MVP docs; app ships with in-memory seed in lib/sample-data.ts.

--- a/lib/ai-prompts.md
+++ b/lib/ai-prompts.md
@@ -1,0 +1,36 @@
+# Sample AI prompts (MVP)
+
+## 1) Note enrichment (title, tags, subject, type)
+System prompt:
+"You are a scientific lab assistant. Given a raw transcript from a voice note, return strict JSON with title, tags, likely_subject, and note_type (observation/result/reminder/issue/next_step). Keep title under 10 words."
+
+User prompt template:
+"Transcript: {{transcript_raw}}\nProject: {{project_name}}\nExperiment: {{experiment_name}}\nSample ID: {{sample_id_or_none}}"
+
+## 2) Daily summary
+System prompt:
+"Summarize one day of lab notes in concise scientific language. Include key observations, anomalies, and next actions."
+
+User prompt template:
+"Date: {{date}}\nNotes JSON: {{notes_json}}"
+
+## 3) Experiment summary
+System prompt:
+"Produce a structured summary with headings: objective, observations, anomalies/problems, next actions."
+
+User prompt template:
+"Experiment: {{experiment_name}}\nObjective: {{objective}}\nNotes JSON: {{notes_json}}"
+
+## 4) Task extraction
+System prompt:
+"Extract action items from notes. Return JSON array with task text, priority (low/medium/high), and rationale."
+
+User prompt template:
+"Notes JSON: {{notes_json}}"
+
+## 5) Natural language retrieval translation
+System prompt:
+"Map a human query to filters for date range, subject, project, experiment, sample_id, and keywords. Return JSON only."
+
+User prompt template:
+"Query: {{user_query}}"

--- a/lib/ai.ts
+++ b/lib/ai.ts
@@ -1,0 +1,53 @@
+import { Note } from "@/lib/types";
+
+export function suggestMetadata(transcript: string) {
+  const lower = transcript.toLowerCase();
+  const tags = [
+    lower.includes("sample") ? "sample" : null,
+    lower.includes("microscopy") ? "microscopy" : null,
+    lower.includes("incubator") ? "incubator" : null,
+    lower.includes("repeat") ? "repeat" : null
+  ].filter(Boolean) as string[];
+
+  const noteType = lower.includes("repeat")
+    ? "next_step"
+    : lower.includes("problem") || lower.includes("issue")
+      ? "issue"
+      : lower.includes("result") || lower.includes("peak")
+        ? "result"
+        : "observation";
+
+  return {
+    title: transcript.split(" ").slice(0, 8).join(" "),
+    tags,
+    likelySubject: lower.includes("microscopy") ? "microscopy" : "cell culture",
+    noteType
+  };
+}
+
+export function summarizeDaily(notes: Note[]) {
+  const issues = notes.filter((n) => n.noteType === "issue").length;
+  const results = notes.filter((n) => n.noteType === "result").length;
+  return `Captured ${notes.length} notes today (${results} results, ${issues} issues). Main focus: ${notes
+    .map((n) => n.title)
+    .slice(0, 3)
+    .join("; ")}.`;
+}
+
+export function summarizeExperiment(notes: Note[]) {
+  const objective = notes[0]?.title ?? "Experiment follow-up";
+  const observations = notes.filter((n) => n.noteType === "observation").map((n) => n.aiSummary);
+  const anomalies = notes.filter((n) => n.noteType === "issue").map((n) => n.aiSummary);
+  const nextActions = notes
+    .filter((n) => ["next_step", "issue"].includes(n.noteType))
+    .map((n) => `- ${n.transcriptEdited}`)
+    .slice(0, 3)
+    .join("\n");
+
+  return {
+    objective,
+    observations,
+    anomalies,
+    nextActions
+  };
+}

--- a/lib/sample-data.ts
+++ b/lib/sample-data.ts
@@ -1,0 +1,126 @@
+import { ExperimentSession, Note, Project, Subject, TaskReminder, User } from "@/lib/types";
+
+export const user: User = {
+  id: "u1",
+  email: "researcher@labassistant.app",
+  name: "Dr. Alex Rivera"
+};
+
+export const projects: Project[] = [
+  { id: "p1", name: "Hydrogel Mechanics", description: "Stiffness tuning for cartilage scaffolds." },
+  { id: "p2", name: "Cell Viability", description: "Chondrocyte response under altered media." }
+];
+
+export const subjects: Subject[] = [
+  { id: "s1", slug: "cell-culture", name: "Cell culture" },
+  { id: "s2", slug: "microscopy", name: "Microscopy" },
+  { id: "s3", slug: "scaffold-fabrication", name: "Scaffold fabrication" },
+  { id: "s4", slug: "finite-element-modeling", name: "Finite element modeling" },
+  { id: "s5", slug: "reagents", name: "Reagents" },
+  { id: "s6", slug: "troubleshooting", name: "Troubleshooting" }
+];
+
+export const experimentSessions: ExperimentSession[] = [
+  {
+    id: "e1",
+    projectId: "p1",
+    subjectId: "s3",
+    name: "Hydrogel Stiffness Run 04",
+    objective: "Compare 4% vs 6% polymer concentration and compressive response.",
+    startedAt: "2026-04-15T08:45:00Z"
+  },
+  {
+    id: "e2",
+    projectId: "p2",
+    subjectId: "s1",
+    name: "Chondrocyte Culture Week 2",
+    objective: "Assess morphology and viability of sample B7 and C2.",
+    startedAt: "2026-04-14T09:10:00Z"
+  }
+];
+
+export const notesSeed: Note[] = [
+  {
+    id: "n1",
+    createdAt: "2026-04-15T09:02:11Z",
+    date: "2026-04-15",
+    audioFileUrl: "/audio/n1.wav",
+    transcriptRaw:
+      "sample b7 gel looked stiffer than expected after uv cure maybe over exposed start repeat prep with shorter exposure",
+    transcriptEdited:
+      "Sample B7 hydrogel appears stiffer than expected after UV curing; possible overexposure. Repeat prep with shorter UV exposure.",
+    aiSummary: "B7 stiffness likely increased by over-curing; repeat with reduced UV duration.",
+    title: "B7 may be over-cured",
+    category: "scaffold fabrication",
+    tags: ["b7", "uv-cure", "stiffness", "repeat"],
+    projectId: "p1",
+    experimentSessionId: "e1",
+    subjectId: "s3",
+    sampleId: "B7",
+    noteType: "issue",
+    linkedTasks: ["t1"]
+  },
+  {
+    id: "n2",
+    createdAt: "2026-04-15T10:18:44Z",
+    date: "2026-04-15",
+    audioFileUrl: "/audio/n2.wav",
+    transcriptRaw:
+      "compression test at point three strain gave peak stress thirty two kilopascals for six percent formulation",
+    transcriptEdited:
+      "Compression test at 0.3 strain produced peak stress of 32 kPa for the 6% formulation.",
+    aiSummary: "6% formulation reached 32 kPa peak stress at 0.3 strain.",
+    title: "6% gel compression result",
+    category: "result",
+    tags: ["compression", "6percent", "kPa"],
+    projectId: "p1",
+    experimentSessionId: "e1",
+    subjectId: "s3",
+    sampleId: "H6-2",
+    noteType: "result",
+    linkedTasks: []
+  },
+  {
+    id: "n3",
+    createdAt: "2026-04-14T11:06:08Z",
+    date: "2026-04-14",
+    audioFileUrl: "/audio/n3.wav",
+    transcriptRaw: "check incubator humidity looked low around fifty percent this morning",
+    transcriptEdited: "Incubator humidity looked low (~50%) this morning. Verify sensor calibration.",
+    aiSummary: "Possible incubator humidity issue requiring calibration check.",
+    title: "Incubator humidity may be low",
+    category: "troubleshooting",
+    tags: ["incubator", "humidity", "calibration"],
+    projectId: "p2",
+    experimentSessionId: "e2",
+    subjectId: "s6",
+    noteType: "issue",
+    linkedTasks: ["t2"]
+  },
+  {
+    id: "n4",
+    createdAt: "2026-04-14T15:22:50Z",
+    date: "2026-04-14",
+    audioFileUrl: "/audio/n4.wav",
+    transcriptRaw:
+      "live dead stain suggests improved viability in c2 compared to b7 get microscopy images and quantify tomorrow",
+    transcriptEdited:
+      "Live/dead stain suggests improved viability in C2 compared to B7. Capture microscopy images and quantify tomorrow.",
+    aiSummary: "C2 viability appears better than B7; imaging and quantification needed.",
+    title: "C2 viability trend",
+    category: "cell culture",
+    tags: ["viability", "c2", "b7", "microscopy"],
+    projectId: "p2",
+    experimentSessionId: "e2",
+    subjectId: "s1",
+    sampleId: "C2",
+    noteType: "observation",
+    linkedTasks: ["t3"]
+  }
+];
+
+export const tasksSeed: TaskReminder[] = [
+  { id: "t1", text: "Repeat sample B7 with shorter UV cure.", done: false, noteId: "n1" },
+  { id: "t2", text: "Check incubator humidity sensor calibration.", done: false, noteId: "n3" },
+  { id: "t3", text: "Analyze microscopy images for C2 vs B7.", done: false, noteId: "n4" }
+];

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -1,0 +1,11 @@
+import { notesSeed, tasksSeed } from "@/lib/sample-data";
+import { Note, TaskReminder } from "@/lib/types";
+
+export const db = {
+  notes: [...notesSeed] as Note[],
+  tasks: [...tasksSeed] as TaskReminder[]
+};
+
+export function getNoteById(id: string): Note | undefined {
+  return db.notes.find((note) => note.id === id);
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,0 +1,66 @@
+export type NoteType = "observation" | "result" | "reminder" | "issue" | "next_step";
+
+export interface User {
+  id: string;
+  email: string;
+  name: string;
+}
+
+export interface Project {
+  id: string;
+  name: string;
+  description?: string;
+}
+
+export interface Subject {
+  id: string;
+  slug: string;
+  name: string;
+}
+
+export interface ExperimentSession {
+  id: string;
+  projectId: string;
+  subjectId: string;
+  name: string;
+  objective: string;
+  startedAt: string;
+}
+
+export interface Tag {
+  id: string;
+  name: string;
+}
+
+export interface TaskReminder {
+  id: string;
+  text: string;
+  done: boolean;
+  noteId: string;
+}
+
+export interface Attachment {
+  id: string;
+  noteId: string;
+  name: string;
+  url: string;
+}
+
+export interface Note {
+  id: string;
+  createdAt: string;
+  date: string;
+  audioFileUrl: string;
+  transcriptRaw: string;
+  transcriptEdited: string;
+  aiSummary: string;
+  title: string;
+  category: string;
+  tags: string[];
+  projectId: string;
+  experimentSessionId: string;
+  subjectId: string;
+  sampleId?: string;
+  noteType: NoteType;
+  linkedTasks: string[];
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    typedRoutes: true
+  }
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "lab-assistant",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.2.5",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  },
+  "devDependencies": {
+    "@types/node": "20.14.9",
+    "@types/react": "18.3.3",
+    "@types/react-dom": "18.3.0",
+    "eslint": "8.57.0",
+    "eslint-config-next": "14.2.5",
+    "typescript": "5.5.2"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
### Motivation
- Deliver a lightweight, voice-first scientific notebook that lets researchers capture observations with a single tap and minimal interruption.
- Provide reliable note capture with timestamps, transcription, project/experiment/subject/sample metadata, and easy retrieval by date, subject, project, experiment, tags, or full text.
- Ship a minimal, modular MVP so STT/LLM providers and persistent storage can be swapped in production without reworking the UX or data model.

### Description
- Scaffolds a Next.js + TypeScript app with core pages and layout: `Dashboard`, `Record`, `Notes` (filters/search), `Experiment` detail, `Subject` view, and `Settings`, plus global styles in `app/globals.css` and `app/layout.tsx`.
- Adds reusable components: `RecordWidget` (large glove-friendly record CTA with mocked transcription flow), `NoteCard`, `NotesFilters`, and `Timeline` for chronological views.
- Implements a small modular data layer and AI helpers: `lib/types.ts`, `lib/sample-data.ts`, in-memory store `lib/store.ts`, and `lib/ai.ts` (metadata suggestions, daily/experiment summarization) plus `lib/ai-prompts.md` for LLM integration templates.
- Provides API routes for note listing/creation (`/api/notes`), note edit (`/api/notes/[id]`), search (`/api/search`), daily summaries (`/api/summaries/daily`), and experiment summaries (`/api/summaries/experiment/[id]`), and includes `db/schema.sql` + `db/seed.sql` for a Postgres/Supabase migration path.
- Documents setup, folder structure, schema, components, API map, and sample data in `README.md`; includes `package.json` and `tsconfig.json` for local development.

### Testing
- Ran `npm install` in this environment which failed due to registry access policy (`403 Forbidden`), so dependency install and automated build/lint checks could not be executed. 
- There are no automated unit tests included in the MVP, so no other automated test suites were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfe2e9f334832d8cf1ff7632c90939)